### PR TITLE
Bug fix: allow "_" to appear anywhere in a Prolog variable's name

### DIFF
--- a/sweeprolog-tests.el
+++ b/sweeprolog-tests.el
@@ -281,30 +281,37 @@ foo(Foo) :- bar.
                    "foo(bar, (_->_;_), _):-_.")))
 
 (sweeprolog-deftest rename-variable ()
-  "Tests renaming varialbes."
+  "Tests renaming variables."
   "foo(Bar,Baz) :- spam(Baz,Bar)."
   (goto-char (point-min))
-  (sweeprolog-rename-variable "Bar" "Spam")
+  (sweeprolog-rename-variable "Bar" "_S_p_a_m_")
   (sweeprolog-rename-variable "Baz" "Bar")
-  (sweeprolog-rename-variable "Spam" "Baz")
+  (sweeprolog-rename-variable "_S_p_a_m_" "Baz")
   (should (string= (buffer-string)
                    "foo(Baz,Bar) :- spam(Bar,Baz).")))
 
 (sweeprolog-deftest increment-variable ()
-  "Tests renaming varialbes."
+  "Tests renaming variables."
   "
 foo(Bar0,Bar) :-
+    spam(Bar_0,Bar_1),
     spam(Bar0,Bar1),
+    bar(Bar_1,Bar_2),
     bar(Bar1,Bar2),
+    baz(Bar_2,Bar),
     baz(Bar2, Bar).
 "
   (goto-char (1+ (point-min)))
   (sweeprolog-increment-numbered-variables 1 (point) "Bar1")
+  (sweeprolog-increment-numbered-variables 1 (point) "Bar_2")
   (should (string= (buffer-string)
                    "
 foo(Bar0,Bar) :-
+    spam(Bar_0,Bar_1),
     spam(Bar0,Bar2),
+    bar(Bar_1,Bar_3),
     bar(Bar2,Bar3),
+    baz(Bar_3,Bar),
     baz(Bar3, Bar).
 ")))
 

--- a/sweeprolog.el
+++ b/sweeprolog.el
@@ -1433,7 +1433,7 @@ list even when found in the current clause."
       (goto-char beg)
       (save-match-data
         (while (re-search-forward (rx bow (or "_" upper)
-                                      (* alnum))
+                                      (* (or "_" alnum)))
                                   end t)
           (unless (nth 8 (syntax-ppss))
             (let ((match (match-string-no-properties 0)))
@@ -6179,7 +6179,8 @@ prompt for CLASS as well.  A negative prefix argument
                                       length)
                               '((?  "next" "Next match")
                                 (?  "back" "Last match")
-                                (?  "exit" "Exit term search"))))
+                                (?
+  "exit" "Exit term search"))))
                       (?
                        (setq overlays (if backward
                                           (cons overlay
@@ -6807,13 +6808,13 @@ is the name of the variable at point, if any."
     (let ((case-fold-search nil))
       (not
        (not
-        (string-match (rx bos (or "_" upper) (* alnum) eos) string))))))
+        (string-match (rx bos (or "_" upper) (* (or "_" alnum)) eos) string))))))
 
 (defun sweeprolog--decode-numbered-variable-name (string)
   "Return t if STRING is valid number variable name."
   (save-match-data
     (let ((case-fold-search nil))
-      (when (string-match (rx bos (group-n 1 (or "_" upper) (or (seq (* alnum) letter)
+      (when (string-match (rx bos (group-n 1 (or "_" upper) (or (seq (* (or "_" alnum)) letter)
                                                                 ""))
                               (group-n 2 (or "0" (seq (any (?1 . ?9)) (* digit)))) eos)
                           string)

--- a/sweeprolog.el
+++ b/sweeprolog.el
@@ -6177,11 +6177,10 @@ prompt for CLASS as well.  A negative prefix argument
                               (format "Match %d/%d"
                                       (1+ index)
                                       length)
-                              '((?  "next" "Next match")
-                                (?  "back" "Last match")
-                                (?
-  "exit" "Exit term search"))))
-                      (?
+                              '((?   "next" "Next match")
+                                (?   "back" "Last match")
+                                (?   "exit" "Exit term search"))))
+                      (?
                        (setq overlays (if backward
                                           (cons overlay
                                                 (reverse (cdr overlays)))
@@ -6191,7 +6190,7 @@ prompt for CLASS as well.  A negative prefix argument
                                        index
                                      (mod (1+ index) length))
                              backward nil))
-                      (?
+                      (?
                        (setq overlays (if backward
                                           (append (cdr overlays)
                                                   (list overlay))


### PR DESCRIPTION
I WAS NOT ABLE TO RUN THE TESTS AFTER I MODIFIED THEM. Running ERT either interactively or in batch mode failed at `(require 'sweeprolog)`. Any guidance is appreciated!

Some regexes used to detect variable names only allow a single underscore at the beginning, so they incorrectly disallow names like `"A_"` and `"A_b_"`.

Please make any edits for style and, if the tests are broken, correctness.